### PR TITLE
git is a prerequisite

### DIFF
--- a/machinekit-documentation/getting-started/APT-packages-jessie.asciidoc
+++ b/machinekit-documentation/getting-started/APT-packages-jessie.asciidoc
@@ -5,6 +5,15 @@
 |link:../documentation-matrix.asciidoc[Documentation matrix]
 |===
 
+
+==== Prerequisite:  
+Install git with
+[source, bash]
+----
+sudo apt-get install git
+----
+as otherwise the installation would not be complete and errorless.
+
 = [[configure-APT-i686-amd64-arm7-jessie]]Configure Apt for i686, amd64 and arm7 (Beaglebone) for `jessie`
 
 ==== Create APT `preferences` file and add `sid` repository


### PR DESCRIPTION
Without git the installation procedures yields no errors,
however halrun can not be started then, see https://gist.github.com/sirop/9ce88bb187a36256d5c5

Probably because of such lines as:
Get:1 http://deb.dovetail-automata.com/ jessie/main machinekit-posix amd64 0.1.1476-1da.bbot.pr763.gitdf5ea66~1jessie

Checked with linux-image-xenomai.x86-amd64 .
